### PR TITLE
fix the datapackage.json source attribute

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -9,16 +9,21 @@
       "id": "ODC-PDDL-1.0"
     }
   ],
+    
+  "sources": [
+    {
+                "name": "World Intellectual Property Organization",
+                "web": "wipo.int/treaties/en/"
+    }
+  ],
+    
   "resources": [
     {
       "name": "membership-to-copyright-treaties",
       "path": "membership-to-copyright-treaties.csv",
       "mediatype": "text/csv",
       "bytes": 38681,
-      "sources": [{
-                  "name": "World Intellectual Property Organization",
-                  "web": "wipo.int/treaties/en/"
-                  }],
+
 
       "schema": {
         "fields": [


### PR DESCRIPTION
The "source" was not appearing on the package page, turns out it was nested inside "resources". I think this should fix it.
